### PR TITLE
Fix link failure on big-endian platforms.

### DIFF
--- a/GOST.xs
+++ b/GOST.xs
@@ -6,6 +6,7 @@
 #include "ppport.h"
 
 #include "src/gost.c"
+#include "src/byte_order.c"
 
 static int
 hex_encode (char *dest, const unsigned char *src, int len) {


### PR DESCRIPTION
On powerpc64 tests failed as:

```
    Failed 2/2 subtests
    ===(       2;0  0/?  0/?  0/? )=========================================Can't load '.../Digest-GOST-0.06/blib/arch/auto/Digest/GOST/GOST.so' for
    module Digest::GOST: .../Digest-GOST-0.06/blib/arch/auto/Digest/GOST/GOST.so: undefined symbol: rhash_u32_swap_copy at /usr/lib64/perl5/5.24.3/powerpc64-linux/DynaLoader.pm line 193.
```

rhash_u32_swap_copy() is a function local to this package.
Seems to be used only for big-endian case.

The fix is to add missing 'src/byte_order.c' file.

All tests pass with patch applied.

Bug: https://bugs.gentoo.org/608214
Bug: https://rt.cpan.org/Public/Bug/Display.html?id=120092
Signed-off-by: Sergei Trofimovich <slyfox@gentoo.org>